### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -24,7 +24,7 @@ Autogen-Tester is a Python framework that integrates Microsoft's AutoGen with th
 ## Technical Requirements
 
 1. **Dependencies**:
-   - Replace pyautogen with autogen-core, autogen-agentchat, and autogen-ext
+   - Replace ag2 with autogen-core, autogen-agentchat, and autogen-ext
    - Maintain compatibility with Playwright >=1.41.0
 
 2. **Agent Implementation**:

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -5,7 +5,7 @@
 ### Core Framework
 - **Python**: Primary programming language (>=3.9)
 - **AutoGen**: LLM agent framework
-  - v0.2 (current): pyautogen >=0.2.0
+  - v0.2 (current): ag2 >=0.2.0
   - v0.4 (target): autogen-core, autogen-agentchat, autogen-ext
 
 ### Web Testing


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
